### PR TITLE
chrony.keys file should not be world readable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,7 +17,7 @@ class chrony::config (
     ensure  => file,
     owner   => 0,
     group   => 0,
-    mode    => '0644',
+    mode    => '0640',
     content => template($config_keys_template),
   }
 


### PR DESCRIPTION
Just ran into this issue in our environment with Chrony.

The key file with sensitive information should by default be protected. Packages default to `0640` octal mode.
