### PR TITLE
secure default installation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@ class chrony (
   $package_name         = $chrony::params::package_name,
   $servers              = $chrony::params::servers,
   $queryhosts           = $chrony::params::queryhosts,
+  $port                 = $chrony::params::port,
   $service_enable       = $chrony::params::service_enable,
   $service_ensure       = $chrony::params::service_ensure,
   $service_manage       = $chrony::params::service_manage,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@ class chrony::params {
   $service_manage   = true
   $chrony_password  = 'xyzzy'
   $queryhosts       = []
+  $port             = 0
 
   case $::osfamily {
     'Archlinux' : {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -10,6 +10,7 @@ describe 'chrony', :type => 'class' do
       }
       it { should compile.with_all_deps }
       it { should_not contain_file('/etc/chrony.conf').with_content(/^allow/) }
+      it { should contain_file('/etc/chrony.conf').with_content(/^port 0$/) }
       ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org'].each do |s|
         it { should contain_file('/etc/chrony.conf').with_content(/^server #{s} iburst$/) }
       end
@@ -23,6 +24,7 @@ describe 'chrony', :type => 'class' do
       }
       it { should compile.with_all_deps }
       it { should_not contain_file('/etc/chrony.conf').with_content(/^allow/) }
+      it { should contain_file('/etc/chrony.conf').with_content(/^port 0$/) }
       ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org'].each do |s|
         it { should contain_file('/etc/chrony.conf').with_content(/^server #{s} iburst$/) }
       end
@@ -36,8 +38,10 @@ describe 'chrony', :type => 'class' do
     }
     let(:params){
       {
-        :queryhosts => ['192.168/16' ]
+        :queryhosts => ['192.168/16' ],
+        :port => '123'
       }
+      it { should contain_file('/etc/chrony.conf').with_content(/^port 123$/) }
       it { should contain_file('/etc/chrony.conf').with_content(/^allow 192\.168\/16$/) }
     }
   end

--- a/templates/chrony.conf.archlinux.erb
+++ b/templates/chrony.conf.archlinux.erb
@@ -192,6 +192,10 @@ allow <%= allowed %>
 
 # You can have as many allow and deny directives as you need.  The order
 # is unimportant.
+#
+
+# http://chrony.tuxfamily.org/manual.html#port-directive
+port <%= @port %>
 
 # If you want chronyd to act as an NTP broadcast server, enable and edit
 # (and maybe copy) the following line.  This means that a broadcast

--- a/templates/chrony.conf.redhat.erb
+++ b/templates/chrony.conf.redhat.erb
@@ -27,6 +27,9 @@ allow <%= allowed %>
 bindcmdaddress 127.0.0.1
 bindcmdaddress ::1
 
+# http://chrony.tuxfamily.org/manual.html#port-directive
+port <%= @port %>
+
 # Serve time even if not synchronized to any NTP server.
 local stratum 10
 


### PR DESCRIPTION
By setting port 0 by default we get a client only installation by
default.
The server behavior can be changed by setting the port parameter
to 123
- http://chrony.tuxfamily.org/manual.html#port-directive
- http://listengine.tuxfamily.org/chrony.tuxfamily.org/chrony-users/2014/01/msg00008.html
