### PR TITLE
Make keys more configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,24 @@ class { '::chrony':
 }
 ```
 
-###I'd like to make sure a secret password is used:
+###I'd like to make sure a secret password is used for chronyc:
 ```puppet
 class { '::chrony':
   servers         => [ 'ntp1.corp.com', 'ntp2.corp.com', ],
   chrony_password => 'secret_password',
+}
+```
+
+###I'd like to use NTP authentication:
+```puppet
+class { '::chrony':
+  keys            => [
+    '25 SHA1 HEX:1dc764e0791b11fa67efc7ecbc4b0d73f68a070c',
+  ],
+  servers         => {
+    'ntp1.corp.com' => ['key 25', 'iburst'],
+    'ntp2.corp.com' => ['key 25', 'iburst'],
+  },
 }
 ```
 
@@ -108,6 +121,10 @@ By default a short fixed string is used. If set explicitly
 to 'unset' then no password will setting will be added 
 to the keys file by puppet.
 
+####`commandkey`
+
+This sets the key ID used by chronyc to authenticate to chronyd.
+
 ####`config`
 
 This sets the file to write chrony configuration into.
@@ -138,6 +155,10 @@ and 0640 on Redhat.
 
 This determines which template puppet should use for the chrony key file.
 
+####`keys`
+
+An array of key lines.  These are printed as-is into the chrony key file.
+
 ####`package_ensure`
 
 This can be set to 'present' or 'latest' or a specific version to choose the
@@ -149,7 +170,8 @@ This determines the name of the package to install.
 
 ####`servers`
 
-This selects the servers to use for ntp peers.
+This selects the servers to use for ntp peers.  It can be an array of servers
+or a hash of servers to their respective options.
 
 ####`queryhosts`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,4 +1,5 @@
 class chrony::config (
+  $commandkey           = $chrony::commandkey,
   $config               = $chrony::config,
   $config_template      = $chrony::config_template,
   $config_keys          = $chrony::config_keys,
@@ -8,6 +9,7 @@ class chrony::config (
   $config_keys_mode     = $chrony::config_keys_mode,
   $config_keys_manage   = $chrony::config_keys_manage,
   $chrony_password      = $chrony::chrony_password,
+  $keys                 = $chrony::keys,
   $servers              = $chrony::servers,) inherits chrony {
   file { $config:
     ensure  => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,5 @@
 class chrony (
+  $commandkey           = $chrony::params::commandkey,
   $config               = $chrony::params::config,
   $config_template      = $chrony::params::config_template,
   $config_keys          = $chrony::params::config_keys,
@@ -8,6 +9,7 @@ class chrony (
   $config_keys_group    = $chrony::params::config_keys_group,
   $config_keys_mode     = $chrony::params::config_keys_mode,
   $config_keys_manage   = $chrony::params::config_keys_manage,
+  $keys                 = $chrony::params::keys,
   $package_ensure       = $chrony::params::package_ensure,
   $package_name         = $chrony::params::package_name,
   $servers              = $chrony::params::servers,
@@ -22,7 +24,6 @@ chrony::params {
   if ! $config_keys_manage and $chrony_password != 'unset'  {
     fail("Setting \$config_keys_manage false and \$chrony_password at same time in ${module_name} is not possible.")
   }
-
 
   include '::chrony::install'
   include '::chrony::config'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,6 @@
 class chrony::params {
+  $commandkey       = 0
+  $keys             = []
   $package_ensure   = 'present'
   $service_enable   = true
   $service_ensure   = 'running'
@@ -19,7 +21,11 @@ class chrony::params {
       $config_keys_mode  = '0644'
       $package_name = 'chrony'
       $service_name = 'chrony'
-      $servers = ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org',]
+      $servers = {
+        '0.pool.ntp.org' => ['iburst'],
+        '1.pool.ntp.org' => ['iburst'],
+        '2.pool.ntp.org' => ['iburst'],
+      }
     }
     'RedHat' : {
       $config = '/etc/chrony.conf'
@@ -31,7 +37,11 @@ class chrony::params {
       $config_keys_mode  = '0640'
       $package_name = 'chrony'
       $service_name = 'chronyd'
-      $servers = ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org',]
+      $servers = {
+        '0.pool.ntp.org' => ['iburst'],
+        '1.pool.ntp.org' => ['iburst'],
+        '2.pool.ntp.org' => ['iburst'],
+      }
     }
 
     default     : {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -18,7 +18,7 @@ describe 'chrony', :type => 'class' do
       it { should contain_file('/etc/chrony.keys').with_owner('0') }
       it { should contain_file('/etc/chrony.keys').with_group('chrony') }
       it { should contain_file('/etc/chrony.keys').with_replace(true) }
-      it { should contain_file('/etc/chrony.keys').with_content("1 xyzzy\n") }
+      it { should contain_file('/etc/chrony.keys').with_content("0 xyzzy\n") }
     end
 
     context 'on archlinux' do
@@ -61,7 +61,7 @@ describe 'chrony', :type => 'class' do
     it { should contain_file('/etc/chrony.keys').with_owner('steve') }
     it { should contain_file('/etc/chrony.keys').with_group('mrt') }
     it { should contain_file('/etc/chrony.keys').with_replace(true) }
-    it { should contain_file('/etc/chrony.keys').with_content("1 sunny\n") }
+    it { should contain_file('/etc/chrony.keys').with_content("0 sunny\n") }
   end
   context 'on redhat with an unmanaged chrony.keys file' do
     let(:facts){

--- a/templates/chrony.conf.archlinux.erb
+++ b/templates/chrony.conf.archlinux.erb
@@ -46,9 +46,11 @@
 ! server ntp0.your-isp.com
 ! server ntp1.your-isp.com
 ! server ntp.public-server.org
-<% Array(@servers).each do |server| -%>
+<% if @servers.is_a?(Hash) then @servers.each do |server, options| -%>
+server <%= server %> <%= options.join(' ') %>
+<% end else Array(@servers).each do |server| -%>
 server <%= server %> iburst
-<% end -%>
+<% end end -%>
 
 #server 0.nl.pool.ntp.org
 #server 1.nl.pool.ntp.org
@@ -112,7 +114,7 @@ keyfile /etc/chrony.keys
 # for chronyc. (You can pick any integer up to 2**32-1.  '1' is just a
 # default.  Using another value will _NOT_ increase security.)
 
-commandkey 1
+commandkey <%= @commandkey %>
 
 # chronyd can save the measurement history for the servers to files when
 # it it exits.  This is useful in 2 situations:

--- a/templates/chrony.conf.redhat.erb
+++ b/templates/chrony.conf.redhat.erb
@@ -1,8 +1,10 @@
 # Use public servers from the pool.ntp.org project.
 # Please consider joining the pool (http://www.pool.ntp.org/join.html).
-<% Array(@servers).each do |server| -%>
+<% if @servers.is_a?(Hash) then @servers.each do |server, options| -%>
+server <%= server %> <%= options.join(' ') %>
+<% end else Array(@servers).each do |server| -%>
 server <%= server %> iburst
-<% end -%>
+<% end end -%>
 
 # Ignore stratum in source selection.
 stratumweight 0
@@ -36,7 +38,7 @@ local stratum 10
 keyfile /etc/chrony.keys
 
 # Specify the key used as password for chronyc.
-commandkey 1
+commandkey <%= @commandkey %>
 
 # Generate command key if missing.
 generatecommandkey

--- a/templates/chrony.keys.archlinux.erb
+++ b/templates/chrony.keys.archlinux.erb
@@ -1,3 +1,6 @@
 <% if @chrony_password and @chrony_password != 'unset' -%>
-1 <%= @chrony_password %>
+<%= @commandkey %> <%= @chrony_password %>
 <% end -%>
+<% if @keys then Array(@keys).each do |line| -%>
+<%= line %>
+<% end end -%>

--- a/templates/chrony.keys.redhat.erb
+++ b/templates/chrony.keys.redhat.erb
@@ -1,3 +1,6 @@
 <% if @chrony_password and @chrony_password != 'unset' -%>
-1 <%= @chrony_password %>
+<%= @commandkey %> <%= @chrony_password %>
 <% end -%>
+<% if @keys then Array(@keys).each do |line| -%>
+<%= line %>
+<% end end -%>


### PR DESCRIPTION
- set default commandkey to 0 (reserved for commands according to chrony docs)
- allow servers to be an array or a hash with options
- configure more than the commandkey in the keys file