### PR TITLE
Implement "makestep" config parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,18 @@ This determines the name of the package to install.
 This selects the servers to use for ntp peers.  It can be an array of servers
 or a hash of servers to their respective options.
 
+#### `makestep_updates`, `makestep_seconds`
+
+This configures the `makestep` parameter of `chronyd`.
+Usually, `chronyd` never steps the time, but applies a slew
+after the initial synchronization.
+This setting configures for how many _updates_ the time may be stepped
+if the adjustment is larger than specified _seconds_.
+
+For virtual machines which are suspended and resumed for a prolonged time,
+stepping the time may be wanted. In this case, set `makestep_updates` to `-1`
+to allow stepping the time for any update.
+
 #### `queryhosts`
 
 This adds the networks, hosts that are allowed to query the daemon.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,8 @@ class chrony (
   $package_name         = $chrony::params::package_name,
   $refclocks            = $chrony::params::refclocks,
   $servers              = $chrony::params::servers,
+  $makestep_seconds     = $chrony::params::makestep_seconds,
+  $makestep_updates     = $chrony::params::makestep_updates,
   $queryhosts           = $chrony::params::queryhosts,
   $mailonchange         = $chrony::params::mailonchange,
   Float $threshold      = $chrony::params::threshold,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,5 +56,7 @@ class chrony::params {
     '2.pool.ntp.org' => ['iburst'],
     '3.pool.ntp.org' => ['iburst'],
   }
+  $makestep_seconds = 10
+  $makestep_updates = 3
 
 }

--- a/templates/chrony.conf.archlinux.erb
+++ b/templates/chrony.conf.archlinux.erb
@@ -329,3 +329,7 @@ rtconutc
 <% if @lock_all -%>
 lock_all
 <% end -%>
+
+# In first <%= @makestep_updates %> updates step the system clock instead of slew
+# if the adjustment is larger than <%= @makestep_seconds %> seconds.
+makestep <%= @makestep_seconds %> <%= @makestep_updates %>

--- a/templates/chrony.conf.debian.erb
+++ b/templates/chrony.conf.debian.erb
@@ -15,9 +15,9 @@ driftfile /var/lib/chrony/drift
 # Enable kernel RTC synchronization.
 rtcsync
 
-# In first three updates step the system clock instead of slew
-# if the adjustment is larger than 10 seconds.
-makestep 10 3
+# In first <%= @makestep_updates %> updates step the system clock instead of slew
+# if the adjustment is larger than <%= @makestep_seconds %> seconds.
+makestep <%= @makestep_seconds %> <%= @makestep_updates %>
 
 # Allow client access from local network.
 #allow 192.168/16

--- a/templates/chrony.conf.redhat.erb
+++ b/templates/chrony.conf.redhat.erb
@@ -15,9 +15,9 @@ driftfile /var/lib/chrony/drift
 # Enable kernel RTC synchronization.
 rtcsync
 
-# In first three updates step the system clock instead of slew
-# if the adjustment is larger than 10 seconds.
-makestep 10 3
+# In first <%= @makestep_updates %> updates step the system clock instead of slew
+# if the adjustment is larger than <%= @makestep_seconds %> seconds.
+makestep <%= @makestep_seconds %> <%= @makestep_updates %>
 
 # Allow client access from local network.
 #allow 192.168/16


### PR DESCRIPTION
Configuring this is crucial to enable time stepping e.g. for VMs,
which may be suspended for longer times. Chronys slew mechanism
is in general not appropriate for such huge time jumps.

This is also recommended in the FAQ for chrony:
https://chrony.tuxfamily.org/faq.html#_is_code_chronyd_code_allowed_to_step_the_system_clock