### PR TITLE
Provide parameter for disabling rtcsync in chrony config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ chrony package to be installed.
 
 This determines the name of the package to install.
 
+#### `rtcsync`
+
+This will enable or disable rtcsync
+
 #### `peers`
 
 This selects the servers to use for NTP peers (symmetric association).

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class chrony (
   $package_ensure                   = $chrony::params::package_ensure,
   $package_name                     = $chrony::params::package_name,
   $refclocks                        = $chrony::params::refclocks,
+  $rtcsync                          = $chrony::params::rtcsync,
   $peers                            = $chrony::params::peers,
   $servers                          = $chrony::params::servers,
   $makestep_seconds                 = $chrony::params::makestep_seconds,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,7 @@ class chrony::params {
   $log_options        = undef
   $package_ensure     = 'present'
   $refclocks          = []
+  $rtcsync            = true
   $peers              = []
   $service_enable     = true
   $service_ensure     = 'running'

--- a/templates/chrony.conf.debian.erb
+++ b/templates/chrony.conf.debian.erb
@@ -16,8 +16,10 @@ stratumweight 0
 # Record the rate at which the system clock gains/losses time.
 driftfile /var/lib/chrony/drift
 
+<% if @rtcsync -%>
 # Enable kernel RTC synchronization.
 rtcsync
+<% end -%>
 
 # In first <%= @makestep_updates %> updates step the system clock instead of slew
 # if the adjustment is larger than <%= @makestep_seconds %> seconds.

--- a/templates/chrony.conf.redhat.erb
+++ b/templates/chrony.conf.redhat.erb
@@ -16,8 +16,10 @@ stratumweight 0
 # Record the rate at which the system clock gains/losses time.
 driftfile /var/lib/chrony/drift
 
+<% if @rtcsync -%>
 # Enable kernel RTC synchronization.
 rtcsync
+<% end -%>
 
 # In first <%= @makestep_updates %> updates step the system clock instead of slew
 # if the adjustment is larger than <%= @makestep_seconds %> seconds.


### PR DESCRIPTION
Making it possible to disable rtcsync via parameter