### PR TITLE
More complex support for refclock

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,19 @@ It is an array of servers.
 This selects the servers to use for NTP servers.  It can be an array of servers
 or a hash of servers to their respective options.
 
+#### `refclocks`
+
+This should be a Hash of hardware reference clock drivers to use.  They hash
+can either list a single list of options for the driver, or any array of
+multiple options if the same driver is used for multiple hardware clocks.
+
+Example:
+```
+refclocks = { 'PPS' => [ '/dev/pps0 lock NMEA refid GPS',
+                         '/dev/pps1:clear refid GPS2' ],
+              'SHM' => '0 offset 0.5 delay 0.2 refid NMEA noselect' }
+```
+
 #### `makestep_updates`, `makestep_seconds`
 
 This configures the `makestep` parameter of `chronyd`.

--- a/templates/chrony.conf.archlinux.erb
+++ b/templates/chrony.conf.archlinux.erb
@@ -313,6 +313,22 @@ rtconutc
 
 ! rtcdevice /dev/misc/rtc
 
+<%- if defined?(@refclocks) -%>
+# Hardware reference clock drivers
+<% if @refclocks.is_a?(Hash) then @refclocks.keys.sort.each do |driver| -%>
+<%   if @refclocks.is_a?(Hash) then @refclocks.keys.sort.each do |driver| -%>
+<%       if @refclocks[driver].is_a(Array) then @refclocks[driver].sort.each do | instance | -%>
+refclock <%= driver %> <%= instance %>
+<%   end end end -%>
+<%   else -%>
+refclock <%= driver %> <%= @refclocks[driver] %>
+<%   end end -%>
+<% else -%>
+<%   Array(@refclocks).sort.each do |refclock| -%>
+refclock <%= refclock %>
+<%   end end -%>
+<% end -%>
+
 #######################################################################
 ### REAL TIME SCHEDULER
 # This directive tells chronyd to use the real-time FIFO scheduler with the

--- a/templates/chrony.conf.debian.erb
+++ b/templates/chrony.conf.debian.erb
@@ -66,8 +66,20 @@ logdir /var/log/chrony
 log <%= @log_options %>
 <%- end -%>
 
-<% Array(@refclocks).each do |refclock| -%>
+<%- if defined?(@refclocks) -%>
+# Hardware reference clock drivers
+<% if @refclocks.is_a?(Hash) then @refclocks.keys.sort.each do |driver| -%>
+<%   if @refclocks.is_a?(Hash) then @refclocks.keys.sort.each do |driver| -%>
+<%       if @refclocks[driver].is_a(Array) then @refclocks[driver].sort.each do | instance | -%>
+refclock <%= driver %> <%= instance %>
+<%   end end end -%>
+<%   else -%>
+refclock <%= driver %> <%= @refclocks[driver] %>
+<%   end end -%>
+<% else -%>
+<%   Array(@refclocks).sort.each do |refclock| -%>
 refclock <%= refclock %>
+<%   end end -%>
 <% end -%>
 
 <% if @lock_all -%>

--- a/templates/chrony.conf.redhat.erb
+++ b/templates/chrony.conf.redhat.erb
@@ -66,8 +66,20 @@ logdir /var/log/chrony
 log <%= @log_options %>
 <%- end -%>
 
-<% Array(@refclocks).each do |refclock| -%>
+<%- if defined?(@refclocks) -%>
+# Hardware reference clock drivers
+<% if @refclocks.is_a?(Hash) then @refclocks.keys.sort.each do |driver| -%>
+<%   if @refclocks.is_a?(Hash) then @refclocks.keys.sort.each do |driver| -%>
+<%       if @refclocks[driver].is_a(Array) then @refclocks[driver].sort.each do | instance | -%>
+refclock <%= driver %> <%= instance %>
+<%   end end end -%>
+<%   else -%>
+refclock <%= driver %> <%= @refclocks[driver] %>
+<%   end end -%>
+<% else -%>
+<%   Array(@refclocks).sort.each do |refclock| -%>
 refclock <%= refclock %>
+<%   end end -%>
 <% end -%>
 
 <% if @lock_all -%>


### PR DESCRIPTION
This lets users setup far more complex refclocks while preserving the existing behavior.  It also adds refclock to the documented parameters.

Examples come from the chrony documentation.