### PR TITLE
Allow configuring bindcmdaddress

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ class { '::chrony':
 
 The following parameters are available in the chrony module
 
+#### `bindcmdaddress`
+
+Array of addresses of interfaces on which chronyd will listen for monitoring
+command packets (defaults to localhost).
+
 #### `chrony_password`
 
 This sets the chrony password to be used in the key file.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,4 +1,5 @@
 class chrony::config (
+  $bindcmdaddress       = $chrony::bindcmdaddress,
   $commandkey           = $chrony::commandkey,
   $config               = $chrony::config,
   $config_template      = $chrony::config_template,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,5 @@
 class chrony (
+  Array[String] $bindcmdaddress     = $chrony::params::bindcmdaddress,
   $commandkey                       = $chrony::params::commandkey,
   $config                           = $chrony::params::config,
   $config_template                  = $chrony::params::config_template,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -66,5 +66,6 @@ class chrony::params {
   $pools                = {}
   $makestep_seconds = 10
   $makestep_updates = 3
+  $bindcmdaddress = ['127.0.0.1', '::1']
 
 }

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -39,6 +39,8 @@ describe 'chrony' do
         when 'RedHat'
           context 'using defaults' do
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*port 0$}) }
+            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindcmdaddress ::1$}) }
+            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindcmdaddress 127\.0\.0\.1$}) }
             ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org'].each do |s|
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*server #{s} iburst$}) }
             end
@@ -51,6 +53,8 @@ describe 'chrony' do
         when 'Debian'
           context 'using defaults' do
             it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*port 0$}) }
+            it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindcmdaddress ::1$}) }
+            it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindcmdaddress 127\.0\.0\.1$}) }
             ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org'].each do |s|
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*server #{s} iburst$}) }
             end
@@ -72,7 +76,8 @@ describe 'chrony' do
             config_keys_owner: 'steve',
             config_keys_group: 'mrt',
             config_keys_manage: true,
-            chrony_password: 'sunny'
+            chrony_password: 'sunny',
+            bindcmdaddress: ['10.0.0.1']
           }
         end
 
@@ -92,6 +97,7 @@ describe 'chrony' do
             context 'with some params passed in' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*port 123$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0123') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_owner('steve') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_group('mrt') }
@@ -102,6 +108,7 @@ describe 'chrony' do
             context 'with some params passed in' do
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*port 123$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_mode('0123') }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_owner('steve') }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_group('mrt') }

--- a/templates/chrony.conf.debian.erb
+++ b/templates/chrony.conf.debian.erb
@@ -35,9 +35,9 @@ makestep <%= @makestep_seconds %> <%= @makestep_updates %>
 allow <%= allowed %>
 <% end -%>
 
-# Listen for commands only on localhost.
-bindcmdaddress 127.0.0.1
-bindcmdaddress ::1
+<% @bindcmdaddress.each do |addr| -%>
+bindcmdaddress <%= addr %>
+<% end -%>
 
 # http://chrony.tuxfamily.org/manual.html#port-directive
 port <%= @port %>

--- a/templates/chrony.conf.redhat.erb
+++ b/templates/chrony.conf.redhat.erb
@@ -35,9 +35,9 @@ makestep <%= @makestep_seconds %> <%= @makestep_updates %>
 allow <%= allowed %>
 <% end -%>
 
-# Listen for commands only on localhost.
-bindcmdaddress 127.0.0.1
-bindcmdaddress ::1
+<% @bindcmdaddress.each do |addr| -%>
+bindcmdaddress <%= addr %>
+<% end -%>
 
 # http://chrony.tuxfamily.org/manual.html#port-directive
 port <%= @port %>


### PR DESCRIPTION
This changeset adds a new parameter to `::chrony` so it's possible to change the value of `bindcmdaddress` which is currently hardcoded to localhost4 and localhost6. The default behaviour is kept.