### PR TITLE
Confirmed RHEL 8 functionality

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,8 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {


### PR DESCRIPTION
Per issue https://github.com/aboe76/puppet-chrony/issues/44 , tested against RHEL8 and revised metadata to reflect this.

Tested ok against RHEL8 and its `chrony-3.3-3.el8.x86_64`.