### PR TITLE
Add parameter $cmdacl

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ By default a short fixed string is used. If set explicitly
 to 'unset' then no password will setting will be added
 to the keys file by puppet.
 
+#### `cmdacl`
+
+An array of ACLs for monitoring access. This expects a list of directives, for
+example: `['cmdallow 1.2.3.4', 'cmddeny 1.2.3']`. The order will be respected at
+the time of generating the configuration. The argument of the allow or deny
+commands can be an address, a partial address or a subnet (see manpage for more
+details).
+
 #### `commandkey`
 
 This sets the key ID used by chronyc to authenticate to chronyd.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,5 +1,6 @@
 class chrony::config (
   $bindcmdaddress       = $chrony::bindcmdaddress,
+  $cmdacl               = $chrony::cmdacl,
   $commandkey           = $chrony::commandkey,
   $config               = $chrony::config,
   $config_template      = $chrony::config_template,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,6 @@
 class chrony (
   Array[String] $bindcmdaddress     = $chrony::params::bindcmdaddress,
+  Array[String] $cmdacl             = $chrony::params::cmdacl,
   $commandkey                       = $chrony::params::commandkey,
   $config                           = $chrony::params::config,
   $config_template                  = $chrony::params::config_template,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class chrony::params {
 
   case $::osfamily {
     'Archlinux' : {
+      $cmdacl            = ['cmdallow 127.0.0.1']
       $config            = '/etc/chrony.conf'
       $config_template   = 'chrony/chrony.conf.archlinux.erb'
       $config_keys       = '/etc/chrony.keys'
@@ -30,6 +31,7 @@ class chrony::params {
       $clientlog         = true
     }
     'Suse', 'RedHat' : {
+      $cmdacl            = []
       $config            = '/etc/chrony.conf'
       $config_template   = 'chrony/chrony.conf.redhat.erb'
       $config_keys       = '/etc/chrony.keys'
@@ -40,6 +42,7 @@ class chrony::params {
       $clientlog         = false
     }
     'Debian' : {
+      $cmdacl            = []
       $config            = '/etc/chrony/chrony.conf'
       $config_template   = 'chrony/chrony.conf.debian.erb'
       $config_keys       = '/etc/chrony/chrony.keys'

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -27,6 +27,7 @@ describe 'chrony' do
         when 'Archlinux'
           context 'using defaults' do
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*port 0$}) }
+            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow 127\.0\.0\.1$}) }
             ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org'].each do |s|
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*server #{s} iburst$}) }
             end
@@ -41,6 +42,7 @@ describe 'chrony' do
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*port 0$}) }
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindcmdaddress ::1$}) }
             it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindcmdaddress 127\.0\.0\.1$}) }
+            it { is_expected.not_to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow.*$}) }
             ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org'].each do |s|
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*server #{s} iburst$}) }
             end
@@ -55,6 +57,7 @@ describe 'chrony' do
             it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*port 0$}) }
             it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindcmdaddress ::1$}) }
             it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindcmdaddress 127\.0\.0\.1$}) }
+            it { is_expected.not_to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdallow.*$}) }
             ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org'].each do |s|
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*server #{s} iburst$}) }
             end
@@ -77,7 +80,8 @@ describe 'chrony' do
             config_keys_group: 'mrt',
             config_keys_manage: true,
             chrony_password: 'sunny',
-            bindcmdaddress: ['10.0.0.1']
+            bindcmdaddress: ['10.0.0.1'],
+            cmdacl: ['cmdallow 1.2.3.4', 'cmddeny 1.2.3', 'cmdallow all 1.2']
           }
         end
 
@@ -87,6 +91,9 @@ describe 'chrony' do
             context 'with some params passed in' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*port 123$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow all 1\.2$}) }
               it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0123') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_owner('steve') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_group('mrt') }
@@ -98,6 +105,9 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*port 123$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow all 1\.2$}) }
               it { is_expected.to contain_file('/etc/chrony.keys').with_mode('0123') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_owner('steve') }
               it { is_expected.to contain_file('/etc/chrony.keys').with_group('mrt') }
@@ -109,6 +119,9 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*port 123$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*cmdallow all 1\.2$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_mode('0123') }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_owner('steve') }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_group('mrt') }

--- a/templates/chrony.conf.archlinux.erb
+++ b/templates/chrony.conf.archlinux.erb
@@ -288,7 +288,9 @@ mailonchange <%= @mailonchange %> <%= @threshold %>
 # necessary, and the problem is being investigated.  You can leave this
 # line enabled, as it's benign otherwise.
 
-cmdallow 127.0.0.1
+<% @cmdacl.each do |acl| -%>
+<%= acl %>
+<% end -%>
 
 #######################################################################
 ### REAL TIME CLOCK

--- a/templates/chrony.conf.debian.erb
+++ b/templates/chrony.conf.debian.erb
@@ -39,6 +39,10 @@ allow <%= allowed %>
 bindcmdaddress <%= addr %>
 <% end -%>
 
+<% @cmdacl.each do |acl| -%>
+<%= acl %>
+<% end -%>
+
 # http://chrony.tuxfamily.org/manual.html#port-directive
 port <%= @port %>
 

--- a/templates/chrony.conf.redhat.erb
+++ b/templates/chrony.conf.redhat.erb
@@ -39,6 +39,10 @@ allow <%= allowed %>
 bindcmdaddress <%= addr %>
 <% end -%>
 
+<% @cmdacl.each do |acl| -%>
+<%= acl %>
+<% end -%>
+
 # http://chrony.tuxfamily.org/manual.html#port-directive
 port <%= @port %>
 


### PR DESCRIPTION
This changeset adds a new parameter `$cmdacl` that allows to set ACLs for monitoring commands using `cmdallow` and `cmddeny`. The previous behaviour on Archlinux is respected by the defaults.

For instance, setting:
```yaml
chrony::cmdacl: ['cmdallow 1.2.3.4', 'cmddeny 1.2.3', 'cmdallow all 1.2']
```

Would result in this snippet being written to the final configuration file:

```
cmdallow 1.2.3.4
cmddeny 1.2.3
cmdallow all 1.2
```

I didn't implement `cmdallow` and `cmddeny` separately because they can be used several times and in the order desired by the caller.