### PR TITLE
Fail if queryhosts is set, but port is at default 0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,13 @@ class { '::chrony':
 ```puppet
 class { '::chrony':
   queryhosts  => [ '192.168/16', ],
+  port        => 123,
 }
 ```
+#### Note
+The parameter `port` is also set here,
+module default is `0` to ensure server mode is not activated accidentally.
+
 
 ## Reference
 
@@ -237,6 +242,12 @@ to allow stepping the time for any update.
 #### `queryhosts`
 
 This adds the networks, hosts that are allowed to query the daemon.
+Note that `port` needs to be set for this to work.
+
+#### `port`
+
+Port the service should listen on, to be used in combination with `queryhosts`.
+Module default is `0` to prevent accidental activation of server mode.
 
 #### `service_enable`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,10 @@ chrony::params {
     fail("Setting \$config_keys_manage false and \$chrony_password at same time in ${module_name} is not possible.")
   }
 
+  if $queryhosts != [] and $port == 0 {
+    fail("Setting \$queryhosts has no effect unless also setting \$port which defaults to 0 in ${module_name}, refusing that.")
+  }
+
   contain '::chrony::install'
   contain '::chrony::config'
   contain '::chrony::service'

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -171,6 +171,16 @@ describe 'chrony' do
         it { is_expected.to raise_error(%r{Setting \$config_keys_manage false and \$chrony_password at same time in chrony is not possible}) }
       end
 
+      context 'queryhosts set but port left at default 0' do
+        let(:params) do
+          {
+            queryhosts: ['192.168/16'],
+          }
+        end
+
+        it { is_expected.to raise_error(%r{Setting \$queryhosts has no effect unless also setting \$port which defaults to 0 in chrony, refusing that}) }
+      end
+
       context 'on any other system' do
         let(:facts) do
           {


### PR DESCRIPTION
Also document this requirement. Port is at 0 by default
to prevent accidental server mode activation, and if queryhosts
is set the user must also configure port, otherwise this has no effect.

closes #29