### PR TITLE
Treat keys file content as Sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Force chrony to only use RAM & prevent swapping.
 
 ## Limitations
 
-This module has been built on and tested against Puppet 3.2.3 and higher.
+This module has been built on and tested against Puppet 5.5 and higher.
 
 The module has been tested on:
  * Arch Linux

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -41,7 +41,7 @@ class chrony::config (
     owner   => $config_keys_owner,
     group   => $config_keys_group,
     mode    => $config_keys_mode,
-    content => template($config_keys_template),
+    content => Sensitive(template($config_keys_template)),
   }
 
 }


### PR DESCRIPTION
This file contains unencrypted shared secrets.  Using `Sensitive` will
stop changes being logged, and exposed in puppetDB etc.