### PR TITLE
Add stratumweight parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,11 @@ How to insert the leap second mode. Use one of possible values only: `leapsecmod
 Override the stratum of the server which will be reported to clients
 when the local reference is active. Defaults to 10
 
+#### `stratumweight`
+
+Sets how much distance should be added per stratum to the synchronisation distance when chronyd selects the synchronisation source from available sources.
+When not set, chronyd's default will be used, which since version 2.0 of chrony, is 0.001 seconds.
+
 #### `log_options`
 
 Specify which information is to be logged.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,6 +26,7 @@ class chrony::config (
   $leapsecmode          = $chrony::leapsecmode,
   $maxslewrate          = $chrony::maxslewrate,
   $smoothtime           = $chrony::smoothtime,
+  $stratumweight        = $chrony::stratumweight,
 ) inherits chrony {
   file { $config:
     ensure  => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,7 @@ class chrony (
   Optional[String] $smoothtime                                     = $chrony::params::smoothtime,
   Optional[Enum['system', 'step', 'slew', 'ignore']] $leapsecmode  = $chrony::params::leapsecmode,
   Optional[Float] $maxslewrate                                     = $chrony::params::maxslewrate,
+  Optional[Numeric] $stratumweight                                 = $chrony::params::stratumweight,
 ) inherits chrony::params {
 
   if ! $config_keys_manage and $chrony_password != 'unset'  {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,7 @@ class chrony::params {
   $smoothtime         = undef
   $leapsecmode        = undef
   $maxslewrate        = undef
+  $stratumweight      = undef
 
   case $::osfamily {
     'Archlinux' : {

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -112,6 +112,7 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*port 123$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdport 257$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^s*allow 192\.168\/16$}) }
+
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*bindcmdaddress 10\.0\.0\.1$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmdallow 1\.2\.3\.4$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*cmddeny 1\.2\.3$}) }
@@ -140,6 +141,31 @@ describe 'chrony' do
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_replace(true) }
               it { is_expected.to contain_file('/etc/chrony/chrony.keys').with_content("0 sunny\n") }
             end
+          end
+        end
+      end
+
+      describe 'stratumweight' do
+        context 'by default' do
+          case facts[:osfamily]
+          when 'Archlinux', 'RedHat'
+            it { is_expected.not_to contain_file('/etc/chrony.conf').with_content(%r{stratumweight}) }
+          when 'Debian'
+            it { is_expected.not_to contain_file('/etc/chrony/chrony.conf').with_content(%r{stratumweight}) }
+          end
+        end
+        context 'when set' do
+          let(:params) do
+            {
+              stratumweight: 0,
+            }
+          end
+
+          case facts[:osfamily]
+          when 'Archlinux', 'RedHat'
+            it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^stratumweight 0$}) }
+          when 'Debian'
+            it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^stratumweight 0$}) }
           end
         end
       end

--- a/templates/chrony.conf.archlinux.erb
+++ b/templates/chrony.conf.archlinux.erb
@@ -10,16 +10,16 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of version 2 of the GNU General Public License as
 # published by the Free Software Foundation.
-# 
+#
 # This program is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-# 
+#
 #
 #######################################################################
 ### COMMENTS
@@ -56,7 +56,7 @@ server <%= server %> iburst
 #server 1.nl.pool.ntp.org
 #server 2.nl.pool.ntp.org
 #server 3.nl.pool.ntp.org
- 
+
 # However, for dial-up use you probably want these instead.  The word
 # 'offline' means that the server is not visible at boot time.  Use
 # chronyc's 'online' command to tell chronyd that these servers have
@@ -85,6 +85,10 @@ pool <%= pool %> iburst
 # probably useless, because you don't know which way the measurement
 # message got held up.)  Consult the full documentation for details.
 
+<% if @stratumweight -%>
+# How much distance should be added per stratum to the synchronisation distance when chronyd selects the synchronisation source from available sources.
+stratumweight <%= @stratumweight %>
+<% end -%>
 #######################################################################
 ### AVOIDING POTENTIALLY BOGUS CHANGES TO YOUR CLOCK
 #
@@ -231,7 +235,7 @@ noclientlog
 
 # The clientlog size is limited to 512KB by default.  If you have many
 # clients, especially in many different subnets, you might want to
-# increase the limit. 
+# increase the limit.
 
 ! clientloglimit 4194304
 <% if defined?(@clientloglimit) -%>

--- a/templates/chrony.conf.debian.erb
+++ b/templates/chrony.conf.debian.erb
@@ -16,9 +16,10 @@ pool <%= pool %> iburst
 peer <%= peer %>
 <% end -%>
 
-# Ignore stratum in source selection.
-stratumweight 0
-
+<% if @stratumweight -%>
+# How much distance should be added per stratum to the synchronisation distance when chronyd selects the synchronisation source from available sources.
+stratumweight <%= @stratumweight %>
+<% end -%>
 # Record the rate at which the system clock gains/losses time.
 driftfile /var/lib/chrony/drift
 

--- a/templates/chrony.conf.redhat.erb
+++ b/templates/chrony.conf.redhat.erb
@@ -16,9 +16,10 @@ pool <%= pool %> iburst
 peer <%= peer %>
 <% end -%>
 
-# Ignore stratum in source selection.
-stratumweight 0
-
+<% if @stratumweight -%>
+# How much distance should be added per stratum to the synchronisation distance when chronyd selects the synchronisation source from available sources.
+stratumweight <%= @stratumweight %>
+<% end -%>
 # Record the rate at which the system clock gains/losses time.
 driftfile /var/lib/chrony/drift
 


### PR DESCRIPTION
Currently, for RedHat and Debian, the module has `stratumweight`
hardcoded to `0`.  Chrony's default has been `0.001` since version 2.0 and
the default configuration file shipped with EL7 doesn't set it to `0`
either. (I suspect a similar situation with modern Debian OSes).

The new parameter defaults to `undef` and leaves out explicitly
configuring `stratumweight` in the configuration file.
This is technically a breaking change as to preserve the
old behaviour, it has to be set to `0`.  I still think this is
preferable to defaulting the parameter to `0` (for OSes other than ArchLinux)
and expecting users to know that `0.001` would be a better choice.