### PR TITLE
Move static defaults out of params.pp

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -110,9 +110,9 @@ The following parameters are available in the `chrony` class.
 
 Data type: `Array[String]`
 
-Array of addresses of interfaces on which chronyd will listen for monitoring command packets (defaults to localhost).
+Array of addresses of interfaces on which chronyd will listen for monitoring command packets.
 
-Default value: $chrony::params::bindcmdaddress
+Default value: ['127.0.0.1', '::1']
 
 ##### `cmdacl`
 
@@ -133,7 +133,7 @@ Data type: `Any`
 The cmdport directive allows the port that is used for run-time monitoring (via the chronyc program)
 to be altered from its default (323).
 
-Default value: $chrony::params::cmdport
+Default value: `undef`
 
 ##### `commandkey`
 
@@ -141,7 +141,7 @@ Data type: `Any`
 
 This sets the key ID used by chronyc to authenticate to chronyd.
 
-Default value: $chrony::params::commandkey
+Default value: 0
 
 ##### `chrony_password`
 
@@ -151,7 +151,7 @@ This sets the chrony password to be used in the key file.
 By default a short fixed string is used. If set explicitly to
 'unset' then no password will be added to the keys file by puppet.
 
-Default value: $chrony::params::chrony_password
+Default value: 'xyzzy'
 
 ##### `config`
 
@@ -183,7 +183,7 @@ Data type: `Any`
 
 This determines which template puppet should use for the chrony key file.
 
-Default value: $chrony::params::config_keys_template
+Default value: 'chrony/chrony.keys.erb'
 
 ##### `config_keys_owner`
 
@@ -215,16 +215,16 @@ Data type: `Any`
 
 An array of key lines.  These are printed as-is into the chrony key file.
 
-Default value: $chrony::params::keys
+Default value: []
 
 ##### `local_stratum`
 
 Data type: `Any`
 
 Override the stratum of the server which will be reported to clients
-when the local reference is active. Defaults to 10.
+when the local reference is active.
 
-Default value: $chrony::params::local_stratum
+Default value: 10
 
 ##### `stratumweight`
 
@@ -234,7 +234,7 @@ Sets how much distance should be added per stratum to the synchronisation distan
 selects the synchronisation source from available sources.
 When not set, chronyd's default will be used, which since version 2.0 of chrony, is 0.001 seconds.
 
-Default value: $chrony::params::stratumweight
+Default value: `undef`
 
 ##### `log_options`
 
@@ -242,7 +242,7 @@ Data type: `Any`
 
 Specify which information is to be logged.
 
-Default value: $chrony::params::log_options
+Default value: `undef`
 
 ##### `package_ensure`
 
@@ -251,7 +251,7 @@ Data type: `Any`
 This can be set to 'present' or 'latest' or a specific version to choose the
 chrony package to be installed.
 
-Default value: $chrony::params::package_ensure
+Default value: 'present'
 
 ##### `package_name`
 
@@ -259,7 +259,7 @@ Data type: `Any`
 
 This determines the name of the package to install.
 
-Default value: $chrony::params::package_name
+Default value: 'chrony'
 
 ##### `peers`
 
@@ -268,7 +268,7 @@ Data type: `Any`
 This selects the servers to use for NTP peers (symmetric association).
 It is an array of servers.
 
-Default value: $chrony::params::peers
+Default value: []
 
 ##### `servers`
 
@@ -277,7 +277,12 @@ Data type: `Any`
 This selects the servers to use for NTP servers.  It can be an array of servers
 or a hash of servers to their respective options.
 
-Default value: $chrony::params::servers
+Default value: {
+    '0.pool.ntp.org' => ['iburst'],
+    '1.pool.ntp.org' => ['iburst'],
+    '2.pool.ntp.org' => ['iburst'],
+    '3.pool.ntp.org' => ['iburst'],
+  }
 
 ##### `refclocks`
 
@@ -294,7 +299,7 @@ refclocks => { 'PPS' => [ '/dev/pps0 lock NMEA refid GPS',
                'SHM' => '0 offset 0.5 delay 0.2 refid NMEA noselect' }
 ```
 
-Default value: $chrony::params::refclocks
+Default value: []
 
 ##### `makestep_seconds`
 
@@ -303,9 +308,9 @@ Data type: `Numeric`
 Configures the [`makestep`](https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#makestep) `threshold`.
 Normally chronyd will cause the system to gradually correct any time offset, by slowing down or speeding up the clock as required.
 If the adjustment is larger than `makestep_seconds`, chronyd will step the clock.
-Also see [`makestep_updates`](#makestep_updates). (Defaults to 10).
+Also see [`makestep_updates`](#makestep_updates).
 
-Default value: $chrony::params::makestep_seconds
+Default value: 10
 
 ##### `makestep_updates`
 
@@ -314,9 +319,9 @@ Data type: `Integer`
 Configures the [`makestep`](https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#makestep) `limit`.
 Chronyd will step the time only if there have been no more than `makestep_updates` clock updates.
 Set to a negative value to disable the limit (useful for virtual machines and laptops that may get suspended for a prolonged time).
-Also see [`makestep_seconds`](#makestep_seconds). (Defaults to 3).
+Also see [`makestep_seconds`](#makestep_seconds).
 
-Default value: $chrony::params::makestep_updates
+Default value: 3
 
 ##### `queryhosts`
 
@@ -325,7 +330,7 @@ Data type: `Any`
 This adds the networks, hosts that are allowed to query the daemon.
 Note that `port` needs to be set for this to work.
 
-Default value: $chrony::params::queryhosts
+Default value: []
 
 ##### `port`
 
@@ -334,7 +339,7 @@ Data type: `Any`
 Port the service should listen on, to be used in combination with `queryhosts`.
 Module default is `0` to prevent accidental activation of server mode.
 
-Default value: $chrony::params::port
+Default value: 0
 
 ##### `service_enable`
 
@@ -342,7 +347,7 @@ Data type: `Any`
 
 This determines if the service should be enabled at boot.
 
-Default value: $chrony::params::service_enable
+Default value: `true`
 
 ##### `service_ensure`
 
@@ -350,7 +355,7 @@ Data type: `Any`
 
 This determines if the service should be running or not.
 
-Default value: $chrony::params::service_ensure
+Default value: 'running'
 
 ##### `service_manage`
 
@@ -358,7 +363,7 @@ Data type: `Any`
 
 This selects if puppet should manage the service in the first place.
 
-Default value: $chrony::params::service_manage
+Default value: `true`
 
 ##### `service_name`
 
@@ -374,7 +379,7 @@ Data type: `Optional[String]`
 
 Specify the smoothing of the time parameter as a string, for example `smoothtime 50000 0.01`.
 
-Default value: $chrony::params::smoothtime
+Default value: `undef`
 
 ##### `mailonchange`
 
@@ -382,7 +387,7 @@ Data type: `Any`
 
 Specify the mail you wanna alert when chronyd executes a sync grater than the `threshold`.
 
-Default value: $chrony::params::mailonchange
+Default value: `undef`
 
 ##### `threshold`
 
@@ -390,7 +395,7 @@ Data type: `Float`
 
 Specify the time limit for triggering events.
 
-Default value: $chrony::params::threshold
+Default value: 0.5
 
 ##### `lock_all`
 
@@ -398,7 +403,7 @@ Data type: `Boolean`
 
 Force chrony to only use RAM & prevent swapping.
 
-Default value: $chrony::params::lock_all
+Default value: `false`
 
 ##### `leapsecmode`
 
@@ -406,7 +411,7 @@ Data type: `Optional[Enum['system', 'step', 'slew', 'ignore']]`
 
 Configures how to insert the leap second mode.
 
-Default value: $chrony::params::leapsecmode
+Default value: `undef`
 
 ##### `maxslewrate`
 
@@ -414,7 +419,7 @@ Data type: `Optional[Float]`
 
 Maximum rate for chronyd to slew the time. Only float type values possible, for example: `maxslewrate 1000.0`.
 
-Default value: $chrony::params::maxslewrate
+Default value: `undef`
 
 ##### `config_keys_manage`
 
@@ -422,7 +427,7 @@ Data type: `Any`
 
 
 
-Default value: $chrony::params::config_keys_manage
+Default value: `true`
 
 ##### `package_source`
 
@@ -430,7 +435,7 @@ Data type: `Optional[String]`
 
 
 
-Default value: $chrony::params::package_source
+Default value: `undef`
 
 ##### `package_provider`
 
@@ -438,7 +443,7 @@ Data type: `Optional[String]`
 
 
 
-Default value: $chrony::params::package_provider
+Default value: `undef`
 
 ##### `pools`
 
@@ -446,7 +451,7 @@ Data type: `Any`
 
 
 
-Default value: $chrony::params::pools
+Default value: {}
 
 ##### `clientlog`
 
@@ -462,5 +467,5 @@ Data type: `Optional[Integer]`
 
 
 
-Default value: $chrony::params::clientloglimit
+Default value: `undef`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,7 @@
 # @see https://chrony.tuxfamily.org
 #
 # @param bindcmdaddress
-#   Array of addresses of interfaces on which chronyd will listen for monitoring command packets (defaults to localhost).
+#   Array of addresses of interfaces on which chronyd will listen for monitoring command packets.
 # @param cmdacl
 #   An array of ACLs for monitoring access. This expects a list of directives, for
 #   example: `['cmdallow 1.2.3.4', 'cmddeny 1.2.3']`. The order will be respected at
@@ -81,7 +81,7 @@
 #   An array of key lines.  These are printed as-is into the chrony key file.
 # @param local_stratum
 #   Override the stratum of the server which will be reported to clients
-#   when the local reference is active. Defaults to 10.
+#   when the local reference is active.
 # @param stratumweight
 #   Sets how much distance should be added per stratum to the synchronisation distance when chronyd
 #   selects the synchronisation source from available sources.
@@ -114,12 +114,12 @@
 #   Configures the [`makestep`](https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#makestep) `threshold`.
 #   Normally chronyd will cause the system to gradually correct any time offset, by slowing down or speeding up the clock as required.
 #   If the adjustment is larger than `makestep_seconds`, chronyd will step the clock.
-#   Also see [`makestep_updates`](#makestep_updates). (Defaults to 10).
+#   Also see [`makestep_updates`](#makestep_updates).
 # @param makestep_updates
 #   Configures the [`makestep`](https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#makestep) `limit`.
 #   Chronyd will step the time only if there have been no more than `makestep_updates` clock updates.
 #   Set to a negative value to disable the limit (useful for virtual machines and laptops that may get suspended for a prolonged time).
-#   Also see [`makestep_seconds`](#makestep_seconds). (Defaults to 3).
+#   Also see [`makestep_seconds`](#makestep_seconds).
 # @param queryhosts
 #   This adds the networks, hosts that are allowed to query the daemon.
 #   Note that `port` needs to be set for this to work.
@@ -147,47 +147,52 @@
 # @param maxslewrate
 #   Maximum rate for chronyd to slew the time. Only float type values possible, for example: `maxslewrate 1000.0`.
 class chrony (
-  Array[String] $bindcmdaddress                                    = $chrony::params::bindcmdaddress,
+  Array[String] $bindcmdaddress                                    = ['127.0.0.1', '::1'],
   Array[String] $cmdacl                                            = $chrony::params::cmdacl,
-  $cmdport                                                         = $chrony::params::cmdport,
-  $commandkey                                                      = $chrony::params::commandkey,
+  $cmdport                                                         = undef,
+  $commandkey                                                      = 0,
   $config                                                          = $chrony::params::config,
   $config_template                                                 = $chrony::params::config_template,
   $config_keys                                                     = $chrony::params::config_keys,
-  $config_keys_template                                            = $chrony::params::config_keys_template,
-  $chrony_password                                                 = $chrony::params::chrony_password,
+  $config_keys_template                                            = 'chrony/chrony.keys.erb',
+  $chrony_password                                                 = 'xyzzy',
   $config_keys_owner                                               = $chrony::params::config_keys_owner,
   $config_keys_group                                               = $chrony::params::config_keys_group,
   $config_keys_mode                                                = $chrony::params::config_keys_mode,
-  $config_keys_manage                                              = $chrony::params::config_keys_manage,
-  $keys                                                            = $chrony::params::keys,
-  $local_stratum                                                   = $chrony::params::local_stratum,
-  $log_options                                                     = $chrony::params::log_options,
-  $package_ensure                                                  = $chrony::params::package_ensure,
-  $package_name                                                    = $chrony::params::package_name,
-  Optional[String] $package_source                                 = $chrony::params::package_source,
-  Optional[String] $package_provider                               = $chrony::params::package_provider,
-  $refclocks                                                       = $chrony::params::refclocks,
-  $peers                                                           = $chrony::params::peers,
-  $servers                                                         = $chrony::params::servers,
-  $pools                                                           = $chrony::params::pools,
-  Numeric $makestep_seconds                                        = $chrony::params::makestep_seconds,
-  Integer $makestep_updates                                        = $chrony::params::makestep_updates,
-  $queryhosts                                                      = $chrony::params::queryhosts,
-  $mailonchange                                                    = $chrony::params::mailonchange,
-  Float $threshold                                                 = $chrony::params::threshold,
-  Boolean $lock_all                                                = $chrony::params::lock_all,
-  $port                                                            = $chrony::params::port,
+  $config_keys_manage                                              = true,
+  $keys                                                            = [],
+  $local_stratum                                                   = 10,
+  $log_options                                                     = undef,
+  $package_ensure                                                  = 'present',
+  $package_name                                                    = 'chrony',
+  Optional[String] $package_source                                 = undef,
+  Optional[String] $package_provider                               = undef,
+  $refclocks                                                       = [],
+  $peers                                                           = [],
+  $servers                                                         = {
+    '0.pool.ntp.org' => ['iburst'],
+    '1.pool.ntp.org' => ['iburst'],
+    '2.pool.ntp.org' => ['iburst'],
+    '3.pool.ntp.org' => ['iburst'],
+  },
+  $pools                                                           = {},
+  Numeric $makestep_seconds                                        = 10,
+  Integer $makestep_updates                                        = 3,
+  $queryhosts                                                      = [],
+  $mailonchange                                                    = undef,
+  Float $threshold                                                 = 0.5,
+  Boolean $lock_all                                                = false,
+  $port                                                            = 0,
   Boolean $clientlog                                               = $chrony::params::clientlog,
-  Optional[Integer] $clientloglimit                                = $chrony::params::clientloglimit,
-  $service_enable                                                  = $chrony::params::service_enable,
-  $service_ensure                                                  = $chrony::params::service_ensure,
-  $service_manage                                                  = $chrony::params::service_manage,
+  Optional[Integer] $clientloglimit                                = undef,
+  $service_enable                                                  = true,
+  $service_ensure                                                  = 'running',
+  $service_manage                                                  = true,
   $service_name                                                    = $chrony::params::service_name,
-  Optional[String] $smoothtime                                     = $chrony::params::smoothtime,
-  Optional[Enum['system', 'step', 'slew', 'ignore']] $leapsecmode  = $chrony::params::leapsecmode,
-  Optional[Float] $maxslewrate                                     = $chrony::params::maxslewrate,
-  Optional[Numeric] $stratumweight                                 = $chrony::params::stratumweight,
+  Optional[String] $smoothtime                                     = undef,
+  Optional[Enum['system', 'step', 'slew', 'ignore']] $leapsecmode  = undef,
+  Optional[Float] $maxslewrate                                     = undef,
+  Optional[Numeric] $stratumweight                                 = undef,
 ) inherits chrony::params {
 
   if ! $config_keys_manage and $chrony_password != 'unset'  {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,32 +2,6 @@
 #
 # @api private
 class chrony::params {
-  $commandkey         = 0
-  $keys               = []
-  $log_options        = undef
-  $package_ensure     = 'present'
-  $package_provider   = undef
-  $package_source     = undef
-  $refclocks          = []
-  $peers              = []
-  $service_enable     = true
-  $service_ensure     = 'running'
-  $service_manage     = true
-  $chrony_password    = 'xyzzy'
-  $queryhosts         = []
-  $local_stratum      = 10
-  $port               = 0
-  $config_keys_manage = true
-  $mailonchange       = undef
-  $threshold          = 0.5
-  $lock_all           = false
-  $clientloglimit     = undef
-  $cmdport            = undef
-  $smoothtime         = undef
-  $leapsecmode        = undef
-  $maxslewrate        = undef
-  $stratumweight      = undef
-
   case $::osfamily {
     'Archlinux' : {
       $cmdacl            = ['cmdallow 127.0.0.1']
@@ -67,17 +41,4 @@ class chrony::params {
       fail("The ${module_name} module is not supported on an ${::osfamily} based system.")
     }
   }
-
-  $config_keys_template = 'chrony/chrony.keys.erb'
-  $package_name         = 'chrony'
-  $servers              = {
-    '0.pool.ntp.org' => ['iburst'],
-    '1.pool.ntp.org' => ['iburst'],
-    '2.pool.ntp.org' => ['iburst'],
-    '3.pool.ntp.org' => ['iburst'],
-  }
-  $pools                = {}
-  $makestep_seconds = 10
-  $makestep_updates = 3
-  $bindcmdaddress = ['127.0.0.1', '::1']
 }


### PR DESCRIPTION
By moving the non OS specific defaults back into init.pp, puppet-strings
can now use them in REFERENCE.md