### PR TITLE
Add `leapsectz` option config option

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,6 +26,7 @@ class chrony::config (
   $pools                = $chrony::pools,
   $port                 = $chrony::port,
   $leapsecmode          = $chrony::leapsecmode,
+  $leapsectz            = $chrony::leapsectz,
   $maxslewrate          = $chrony::maxslewrate,
   $smoothtime           = $chrony::smoothtime,
   $stratumweight        = $chrony::stratumweight,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -156,6 +156,8 @@
 #   Force chrony to only use RAM & prevent swapping.
 # @param leapsecmode
 #   Configures how to insert the leap second mode.
+# @param leapsectz
+#   Specifies a timezone that chronyd can use to determine the offset between UTC and TAI.
 # @param maxslewrate
 #   Maximum rate for chronyd to slew the time. Only float type values possible, for example: `maxslewrate 1000.0`.
 # @param clientlog
@@ -209,6 +211,7 @@ class chrony (
   String[1] $service_name                                          = $chrony::params::service_name,
   Optional[String] $smoothtime                                     = undef,
   Optional[Enum['system', 'step', 'slew', 'ignore']] $leapsecmode  = undef,
+  Optional[String] $leapsectz                                      = undef,
   Optional[Float] $maxslewrate                                     = undef,
   Optional[Numeric] $stratumweight                                 = undef,
 ) inherits chrony::params {

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -84,6 +84,7 @@ describe 'chrony' do
             bindcmdaddress: ['10.0.0.1'],
             cmdacl: ['cmdallow 1.2.3.4', 'cmddeny 1.2.3', 'cmdallow all 1.2'],
             leapsecmode: 'slew',
+            leapsectz: 'right/UTC',
             maxslewrate: 1000.0,
             smoothtime: '400 0.001 leaponly',
           }
@@ -107,6 +108,7 @@ describe 'chrony' do
           when 'RedHat'
             context 'with some params passed in' do
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*leapsecmode slew$}) }
+              it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*leapsectz right/UTC$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*maxslewrate 1000\.0$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*smoothtime 400 0\.001 leaponly$}) }
               it { is_expected.to contain_file('/etc/chrony.conf').with_content(%r{^\s*port 123$}) }
@@ -125,6 +127,7 @@ describe 'chrony' do
             end
           when 'Debian'
             context 'with some params passed in' do
+              it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*leapsectz right/UTC$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*leapsecmode slew$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*maxslewrate 1000\.0$}) }
               it { is_expected.to contain_file('/etc/chrony/chrony.conf').with_content(%r{^\s*smoothtime 400 0\.001 leaponly$}) }

--- a/templates/chrony.conf.debian.erb
+++ b/templates/chrony.conf.debian.erb
@@ -107,6 +107,11 @@ lock_all
 leapsecmode <%= @leapsecmode %>
 <% end -%>
 
+# https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#leapsectz
+<% if defined?(@leapsectz) %>
+leapsectz <%= @leapsectz %>
+<% end -%>
+
 # https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#maxslewrate
 <% if defined?(@maxslewrate) %>
 maxslewrate <%= @maxslewrate %>

--- a/templates/chrony.conf.redhat.erb
+++ b/templates/chrony.conf.redhat.erb
@@ -107,6 +107,11 @@ lock_all
 leapsecmode <%= @leapsecmode %>
 <% end -%>
 
+# https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#leapsectz
+<% if defined?(@leapsectz) %>
+leapsectz <%= @leapsectz %>
+<% end -%>
+
 # https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#maxslewrate
 <% if defined?(@maxslewrate) %>
 maxslewrate <%= @maxslewrate %>


### PR DESCRIPTION
This pull request exposes the `leapsectz` option, which when set uses a specified offset from UTC to set `CLOCK_TAI`.

This current revision has tests but could probably benefit from additional work. In addition it looks like the `leapsecmode` option isn't plumbed through on archlinux and I haven't pushed `leapsectz` through either. I'm happy to fix that in another PR or incorporate those fixes here.