### PR TITLE
Allow the password to be a Sensitive string.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,12 +18,25 @@ class chrony::config {
     ),
   }
 
+  if $chrony::chrony_password =~ Sensitive {
+    # unwrap before Puppet 6.24 can only be called on Sensitive values
+    $chrony_password = $chrony::chrony_password.unwrap
+  } else {
+    $chrony_password = $chrony::chrony_password
+  }
+
+  $keys_params = {
+    'chrony_password' => $chrony_password,
+    'commandkey' => $chrony::commandkey,
+    'keys' => $chrony::keys,
+  }
+
   file { $chrony::config_keys:
     ensure  => file,
     replace => $chrony::config_keys_manage,
     owner   => $chrony::config_keys_owner,
     group   => $chrony::config_keys_group,
     mode    => $chrony::config_keys_mode,
-    content => Sensitive(epp($chrony::config_keys_template)),
+    content => Sensitive(epp($chrony::config_keys_template, $keys_params)),
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -246,7 +246,7 @@ class chrony (
   String[1] $config_template                                       = 'chrony/chrony.conf.epp',
   Stdlib::Unixpath $config_keys                                    = '/etc/chrony/chrony.keys',
   String[1] $config_keys_template                                  = 'chrony/chrony.keys.epp',
-  String[1] $chrony_password                                       = 'xyzzy',
+  Variant[Sensitive[String[1]], String[1]] $chrony_password        = 'xyzzy',
   Variant[Integer[0],String[1]] $config_keys_owner                 = 0,
   Variant[Integer[0],String[1]] $config_keys_group                 = 0,
   Stdlib::Filemode $config_keys_mode                               = '0640',

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -144,7 +144,7 @@ describe 'chrony' do
             config_keys_manage: true,
             confdir: '/tmp/chroconf',
             sourcedir: '/tmp/chrosources',
-            chrony_password: 'sunny',
+            chrony_password: sensitive('sunny'),
             bindaddress: ['10.0.0.1', '::1'],
             bindcmdaddress: ['10.0.0.1'],
             initstepslew: '600',

--- a/templates/chrony.keys.epp
+++ b/templates/chrony.keys.epp
@@ -1,6 +1,11 @@
-<% if $chrony::chrony_password and $chrony::chrony_password != 'unset' { -%>
-<%= $chrony::commandkey %> <%= $chrony::chrony_password %>
+<% |
+  String[1] $chrony_password,
+  NotUndef $commandkey,
+  Array[String[1]] $keys,
+| -%>
+<% if $chrony_password != 'unset' { -%>
+<%= $commandkey %> <%= $chrony_password %>
 <% } -%>
-<% $chrony::keys.each |$line| { -%>
+<% $keys.each |$line| { -%>
 <%= $line %>
 <% } -%>


### PR DESCRIPTION
#### Pull Request (PR) description
For folks doing mass casting of .*password.* to Sensitive,
this should help keep chrony working as expected.

#### This Pull Request (PR) fixes the following issues
N/A