### PR TITLE
Add Debian family defaults for `confdir` and `sourcedir`

### DIFF
--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,4 +1,5 @@
 ---
+chrony::confdir: /etc/chrony/conf.d
 chrony::config_keys_group: _chrony
 chrony::driftfile: /var/lib/chrony/chrony.drift
 chrony::leapseclist: /usr/share/zoneinfo/leap-seconds.list
@@ -11,3 +12,6 @@ chrony::pools:
   2.debian.pool.ntp.org:
     - iburst
 chrony::servers: {}
+chrony::sourcedir:
+  - /run/chrony-dhcp
+  - /etc/chrony/sources.d

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -269,7 +269,12 @@ describe 'chrony' do
 
       describe 'confdir' do
         context 'by default' do
-          it { is_expected.not_to contain_file(config_file).with_content(%r{confdir}) }
+          case facts[:os]['family']
+          when 'Debian'
+            it { is_expected.to contain_file(config_file).with_content(%r{^confdir /etc/chrony/conf\.d$}) }
+          else
+            it { is_expected.not_to contain_file(config_file).with_content(%r{confdir}) }
+          end
         end
 
         context 'when set to a single path' do
@@ -296,7 +301,13 @@ describe 'chrony' do
 
       describe 'sourcedir' do
         context 'by default' do
-          it { is_expected.not_to contain_file(config_file).with_content(%r{sourcedir}) }
+          case facts[:os]['family']
+          when 'Debian'
+            it { is_expected.to contain_file(config_file).with_content(%r{^sourcedir /etc/chrony/sources\.d$}) }
+            it { is_expected.to contain_file(config_file).with_content(%r{^sourcedir /run/chrony-dhcp$}) }
+          else
+            it { is_expected.not_to contain_file(config_file).with_content(%r{sourcedir}) }
+          end
         end
 
         context 'when set to a single path' do


### PR DESCRIPTION
#### Pull Request (PR) description

Set the defaults for these to params on the Debian family:

* `confdir`: `/etc/chrony/conf.d`
* `sourcedir`: `/etc/chrony/sources.d`, `/run/chrony-dhcp`

Seems like both Debian and Ubuntu use the same settings for these.

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-chrony/issues/241
