### PR TITLE
Set default pool for Ubuntu and Debian

### DIFF
--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -7,3 +7,7 @@ chrony::maxupdateskew: 100.0
 chrony::ntsdumpdir: /var/lib/chrony
 chrony::options_template: chrony/chronyd_default.epp
 chrony::options_file: /etc/default/chrony
+chrony::pools:
+  2.debian.pool.ntp.org:
+    - iburst
+chrony::servers: {}

--- a/data/Ubuntu.yaml
+++ b/data/Ubuntu.yaml
@@ -1,2 +1,6 @@
 chrony::leapseclist: ~
 chrony::leapsectz: right/UTC
+chrony::pools:
+  ntp.ubuntu.com:
+    - iburst
+    - maxsources 4

--- a/spec/classes/chrony_spec.rb
+++ b/spec/classes/chrony_spec.rb
@@ -116,8 +116,12 @@ describe 'chrony' do
             it { is_expected.to contain_file(config_file).with_content(%r{^\s*bindcmdaddress 127\.0\.0\.1$}) }
             it { is_expected.not_to contain_file(config_file).with_content(%r{^\s*cmdallow.*$}) }
 
-            ['0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org'].each do |s|
-              it { is_expected.to contain_file(config_file).with_content(%r{^\s*server #{s} iburst$}) }
+            it { is_expected.not_to contain_file(config_file).with_content(%r{^\s*server }) }
+
+            if facts[:os]['name'] == 'Ubuntu'
+              it { is_expected.to contain_file(config_file).with_content(%r{^\s*pool ntp.ubuntu.com iburst maxsources 4$}) }
+            else
+              it { is_expected.to contain_file(config_file).with_content(%r{^\s*pool 2.debian.pool.ntp.org iburst$}) }
             end
 
             it { is_expected.to contain_file(config_file).with_content(%r{^\s*driftfile /var/lib/chrony/chrony.drift$}) }
@@ -335,14 +339,19 @@ describe 'chrony' do
 
       describe 'servers' do
         context 'by default' do
-          it do
-            expected_lines = [
-              'server 0.pool.ntp.org iburst',
-              'server 1.pool.ntp.org iburst',
-              'server 2.pool.ntp.org iburst',
-              'server 3.pool.ntp.org iburst',
-            ]
-            expect(config_file_contents.split("\n") & expected_lines).to eq(expected_lines)
+          case facts[:os]['family']
+          when 'Debian'
+            it { expect(config_file_contents).not_to match(%r{^server }) }
+          else
+            it do
+              expected_lines = [
+                'server 0.pool.ntp.org iburst',
+                'server 1.pool.ntp.org iburst',
+                'server 2.pool.ntp.org iburst',
+                'server 3.pool.ntp.org iburst',
+              ]
+              expect(config_file_contents.split("\n") & expected_lines).to eq(expected_lines)
+            end
           end
         end
 
@@ -388,7 +397,16 @@ describe 'chrony' do
 
       describe 'pools' do
         context 'by default' do
-          it { expect(config_file_contents).not_to match(%r{^pool}) }
+          case facts[:os]['family']
+          when 'Debian'
+            if facts[:os]['name'] == 'Ubuntu'
+              it { expect(config_file_contents).to match(%r{^pool ntp.ubuntu.com iburst maxsources 4$}) }
+            else
+              it { expect(config_file_contents).to match(%r{^pool 2.debian.pool.ntp.org iburst$}) }
+            end
+          else
+            it { expect(config_file_contents).not_to match(%r{^pool}) }
+          end
         end
 
         context 'when pools is an array' do
@@ -400,8 +418,8 @@ describe 'chrony' do
 
           it do
             expected_lines = [
-              'server 0.pool.ntp.org iburst',
-              'server 1.pool.ntp.org iburst',
+              'pool 0.pool.ntp.org iburst',
+              'pool 1.pool.ntp.org iburst',
             ]
             expect(config_file_contents.split("\n") & expected_lines).to eq(expected_lines)
           end


### PR DESCRIPTION
#### Pull Request (PR) description

Set the default server/pool setting for Ubuntu and Debian to the OS defaults.

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-chrony/issues/243
